### PR TITLE
Remove arch from manifest.json

### DIFF
--- a/aarch64/app/manifest.json
+++ b/aarch64/app/manifest.json
@@ -17,6 +17,5 @@
         "configuration":  {
           "settingPage": "index.html"
         }
-     
       }
   }

--- a/aarch64/app/manifest.json
+++ b/aarch64/app/manifest.json
@@ -2,7 +2,6 @@
   "schemaVersion": "1.3",
   "acapPackageConf": {
       "setup": {
-        "architecture": "aarch64",
           "appName": "Tailscale_VPN",
           "friendlyName": "Tailscale VPN",
           "vendor": "Tailscale - Packaged by Axis Labs",

--- a/arm/app/manifest.json
+++ b/arm/app/manifest.json
@@ -4,7 +4,7 @@
       "setup": {
           "appName": "Tailscale_VPN",
           "friendlyName": "Tailscale VPN",
-          "vendor": "Tailscale - Packaged by Axis Axis Labs",
+          "vendor": "Tailscale - Packaged by Axis Labs",
           "embeddedSdkVersion": "3.0",
           "user": {
               "group": "root",
@@ -13,10 +13,9 @@
           "vendorUrl": "https://www.tailscale.com",
           "runMode": "once",
           "version": "1.38.4"
-      },
-      "configuration":  {
-        "settingPage": "index.html"
-      }
-     
+        },
+        "configuration":  {
+          "settingPage": "index.html"
+        }
       }
   }

--- a/arm/app/manifest.json
+++ b/arm/app/manifest.json
@@ -2,7 +2,6 @@
   "schemaVersion": "1.3",
   "acapPackageConf": {
       "setup": {
-        "architecture": "armv7hf",
           "appName": "Tailscale_VPN",
           "friendlyName": "Tailscale VPN",
           "vendor": "Tailscale - Packaged by Axis Axis Labs",


### PR DESCRIPTION
According to [Manifest schemas](https://axiscommunications.github.io/acap-documentation/docs/develop/manifest-schemas/) and [Manifest schemas v1.3](https://axiscommunications.github.io/acap-documentation/docs/develop/manifest-schemas/schema-field-descriptions-v1.3.html), the `architecture` field is optional.

Tested by building and inspecting the `manifest.json` in the resulting `.eap` files -- they are correct for both `aarch64` and `armv7hf`.

With these changes the `manifest.json` is identical between the two architectures, hopefully allowing for some future refactoring.