### PR TITLE
feat: ability to route traffic to other tailnet nodes using SOCKS5 proxy

### DIFF
--- a/aarch64/app/Tailscale_VPN
+++ b/aarch64/app/Tailscale_VPN
@@ -3,7 +3,7 @@
     echo "Starting Service"
     chmod 777 /usr/local/packages/Tailscale_VPN/lib/tailscale
     chmod 777 /usr/local/packages/Tailscale_VPN/lib/tailscaled
-    /usr/local/packages/Tailscale_VPN/lib/tailscaled --tun=userspace-networking --socket=/usr/local/packages/Tailscale_VPN/tailscaled.sock &
+    /usr/local/packages/Tailscale_VPN/lib/tailscaled --socks5-server=localhost:1055 --tun=userspace-networking --socket=/usr/local/packages/Tailscale_VPN/tailscaled.sock &
     echo "Service Started"
     echo "Scroll to Bottom for link"
     /usr/local/packages/Tailscale_VPN/lib/tailscale --socket=/usr/local/packages/Tailscale_VPN/tailscaled.sock up


### PR DESCRIPTION
Fixes #21 

With `--socks5-server=localhost:1055` argument, the camera can access other nodes in the taillnet. More info about the subject at Tailscale docs [Userspace networking mode (for containers)
](https://tailscale.com/kb/1112/userspace-networking#socks5-vs-http)

How I tested this:
I ran this on a camera with the OS version 12.5.68.
I had a web server running on another node on port 8080 and was able to access the node through Tailscale with the following command:
```sh
ALL_PROXY=socks5://127.0.0.1:1055 curl http://<ip>:8080
```